### PR TITLE
Add unit declarator to module and class declarations

### DIFF
--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -4,7 +4,7 @@ use Bailador::Response;
 use Bailador::Context;
 use HTTP::Easy::PSGI;
 
-module Bailador;
+unit module Bailador;
 
 my $app = Bailador::App.current;
 

--- a/lib/Bailador/Template/Mojo.pm
+++ b/lib/Bailador/Template/Mojo.pm
@@ -1,6 +1,6 @@
 use Bailador::Template;
 
-class Bailador::Template::Mojo does Bailador::Template;
+unit class Bailador::Template::Mojo does Bailador::Template;
 use Template::Mojo;
 
 has $!engine = Template::Mojo;

--- a/lib/Bailador/Test.pm
+++ b/lib/Bailador/Test.pm
@@ -3,7 +3,7 @@ use Bailador;
 use Bailador::Request;
 use URI;
 
-module Bailador::Test;
+unit module Bailador::Test;
 
 # preparing a environment variale for PSGI
 sub get-psgi-response($meth, $url, $data = '') is export {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.