### PR TITLE
Reset headers between requests

### DIFF
--- a/lib/Bailador/Context.pm
+++ b/lib/Bailador/Context.pm
@@ -13,6 +13,7 @@ class Bailador::Context {
                 # reset response to default
                 $!response.code    = 404;
                 $!response.content = 'Not found';
+                $!response.headers = {};
                 $!response.headers<Content-Type> = 'text/html';
                 $!request.env = $!env = $value;
             },

--- a/t/03-response-content.t
+++ b/t/03-response-content.t
@@ -2,7 +2,7 @@ use Test;
 use Bailador;
 use Bailador::Test;
 
-plan 9;
+plan 11;
 
 get '/foo' => sub { "foo text" }
 post '/bar' => sub { "peti bar" }
@@ -11,6 +11,16 @@ get '/baz' => sub { { foo => "bar", baz => 5 } }
 
 get '/params/:foo'    => sub ($foo) { "a happy $foo" }
 get /'/regexes/'(.+)/ => sub ($foo) { "a happy $foo" }
+
+get '/header1' => sub {
+    header("X-Test", "header1");
+    "added header X-Test";
+}
+
+get '/header2' => sub {
+    header("X-Again", "header2");
+    "added header X-Again";
+}
 
 is-deeply get-psgi-response('GET',  '/foo'),  [200, ["Content-Type" => "text/html"], 'foo text'],       'route GET /foo returns content';
 is-deeply get-psgi-response('POST', '/bar'),  [200, ["Content-Type" => "text/html"], 'peti bar'],       'route POST /bar returns content';
@@ -31,3 +41,6 @@ is-deeply $res[1], ["Content-Type" => "text/html"], 'header';
 todo 'returning complex structs NYI';
 is-deeply $res[2], { foo => "bar", baz => 5 }; # this should be json, right? 
 
+is-deeply get-psgi-response('GET', '/header1'), [ 200, ["X-Test" => "header1", "Content-Type" => "text/html" ], "added header X-Test" ], 'ROUTE GET /header1 sends an extra header';
+
+is-deeply get-psgi-response('GET',  '/header2'),  [ 200, ["X-Again" => "header2", "Content-Type" => "text/html"], 'added header X-Again' ], 'ROUTE GET /header2 sends an extra and does not include headers from previous requests';


### PR DESCRIPTION
This prevents headers sent in a response persisting across all future requests (I don't think this was the intended behaviour?)

Also added a couple of tests for adding headers.