### PR TITLE
Add an easier way to send cookies

### DIFF
--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -3,6 +3,7 @@ use Bailador::Request;
 use Bailador::Response;
 use Bailador::Context;
 use HTTP::Easy::PSGI;
+use URI::Escape;
 
 unit module Bailador;
 
@@ -74,7 +75,7 @@ sub header(Str $name, Cool $value) is export {
 
 sub cookie(Str $name, Str $value, Str :$domain, Str :$path,
         DateTime :$expires, Bool :$http-only; Bool :$secure) is export {
-    my $c = "$value";
+    my $c = uri_escape($value);
     if $path    { $c ~= "; Path=$path" }
     if $domain  { $c ~= "; Domain=$domain" }
     if $expires {
@@ -109,7 +110,7 @@ sub cookie(Str $name, Str $value, Str :$domain, Str :$path,
     }
     if $secure    { $c ~= "; Secure" }
     if $http-only { $c ~= "; HttpOnly" }
-    $app.response.cookies.push: "$name=$c";
+    $app.response.cookies.push: uri_escape($name) ~ "=$c";
 }
 
 sub status(Int $code) is export {

--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -72,6 +72,46 @@ sub header(Str $name, Cool $value) is export {
     $app.response.headers{$name} = ~$value;
 }
 
+sub cookie(Str $name, Str $value, Str :$domain, Str :$path,
+        DateTime :$expires, Bool :$http-only; Bool :$secure) is export {
+    my $c = "$value";
+    if $path    { $c ~= "; Path=$path" }
+    if $domain  { $c ~= "; Domain=$domain" }
+    if $expires {
+        my $dt = $expires.utc;
+        my $wdy = do given $dt.day-of-week {
+            when 1 { <Mon> }
+            when 2 { <Tue> }
+            when 3 { <Wed> }
+            when 4 { <Thu> }
+            when 5 { <Fri> }
+            when 6 { <Sat> }
+            when 7 { <Sun> }
+        }
+        my $day = $dt.day-of-month.fmt('%02d');
+        my $mon = do given $dt.month {
+            when 1  { <Jan> }
+            when 2  { <Feb> }
+            when 3  { <Mar> }
+            when 4  { <Apr> }
+            when 5  { <May> }
+            when 6  { <Jun> }
+            when 7  { <Jul> }
+            when 8  { <Aug> }
+            when 9  { <Sep> }
+            when 10 { <Oct> }
+            when 11 { <Nov> }
+            when 12 { <Dec> }
+        }
+        my $year = $dt.year.fmt('%04d');
+        my $time = sprintf('%02d:%02d:%02d', $dt.hour, $dt.minute, $dt.second);
+        $c ~= "; Expires=$wdy, $day $mon $year $time GMT";
+    }
+    if $secure    { $c ~= "; Secure" }
+    if $http-only { $c ~= "; HttpOnly" }
+    $app.response.cookies.push: "$name=$c";
+}
+
 sub status(Int $code) is export {
     $app.response.code = $code;
 }

--- a/lib/Bailador/Context.pm
+++ b/lib/Bailador/Context.pm
@@ -14,6 +14,7 @@ class Bailador::Context {
                 $!response.code    = 404;
                 $!response.content = 'Not found';
                 $!response.headers<Content-Type> = 'text/html';
+                $!response.cookies = ();
                 $!request.env = $!env = $value;
             },
         );

--- a/lib/Bailador/Response.pm
+++ b/lib/Bailador/Response.pm
@@ -2,8 +2,11 @@ class Bailador::Response {
     has $.code     is rw;
     has %.headers  is rw;
     has @.content  is rw;
+    has @.cookies  is rw;
 
     method psgi {
-        [ $.code, [ %.headers.list ], |@.content ]
+        my @headers = %.headers.list;
+        for @.cookies { @headers.push("Set-Cookie" => $_) }
+        [ $.code, [ @headers ], |@.content ]
     }
 }

--- a/t/06-cookies.t
+++ b/t/06-cookies.t
@@ -1,0 +1,99 @@
+use v6;
+use Test;
+use Bailador;
+use Bailador::Test;
+
+plan 12;
+
+get '/cook1' => sub {
+    cookie("flavour", "chocolate");
+    "cookie test #1";
+}
+
+get '/cook2' => sub {
+    cookie("flavour", "chocolate", domain => "example.com");
+    "cookie test #2";
+}
+
+get '/cook3' => sub {
+    cookie("flavour", "chocolate", path => "/test");
+    "cookie test #3";
+}
+
+get '/cook4' => sub {
+    cookie("flavour", "chocolate", path => "/test", domain => "example.com");
+    "cookie test #4";
+}
+
+get '/cook5' => sub {
+    cookie("flavour", "chocolate", expires => DateTime.new("2021-06-09T01:18:14-09"));
+    "cookie test #5";
+}
+
+get '/rfc1' => sub {
+    cookie("SID", "31d4d96e407aad42");
+    "rfc";
+}
+
+get '/rfc2' => sub {
+    cookie("SID", "31d4d96e407aad42", path=> "/", domain => "example.com");
+    "rfc";
+}
+get '/rfc3' => sub {
+    cookie("SID", "31d4d96e407aad42", path=> "/", :secure, :http-only);
+    "rfc";
+}
+
+get '/rfc4' => sub {
+    cookie("lang", "", expires => DateTime.new("1994-11-06T08:49:37"));
+    "rfc";
+}
+
+get '/wiki1' => sub {
+    cookie("LSID", "DQAAAKEaem_vYg", path => "/accounts", expires => DateTime.new("2021-01-13T22:23:01"), :secure, :http-only);
+    "wikipedia";
+}
+
+get '/wiki2' => sub {
+    cookie("SSID", "Ap4P.GTEq", domain => "foo.com", path => "/", expires => DateTime.new("2021-01-13T22:23:01"), :secure, :http-only);
+    "wikipedia";
+}
+
+get '/multi1' => sub {
+    cookie("enwikiUserID", "127001", expires => DateTime.new("2015-10-15T15:12:40"), path => '/', :secure, :http-only);
+    cookie("enwikiUserName", "localhost", expires => DateTime.new("2015-10-15T15:12:40"), path => '/', :secure, :http-only);
+    cookie("forceHTTPS", "true", expires => DateTime.new("2015-10-15T15:12:40"), path => '/', :http-only);
+    "multiple";
+}
+
+is-deeply get-psgi-response('GET', '/cook1'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "flavour=chocolate"], "cookie test #1" ], 'ROUTE GET /cook1 sets a cookie';
+
+is-deeply get-psgi-response('GET', '/cook2'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "flavour=chocolate; Domain=example.com"], "cookie test #2" ], 'ROUTE GET /cook2 sets a cookie with a domain';
+
+is-deeply get-psgi-response('GET', '/cook3'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "flavour=chocolate; Path=/test"], "cookie test #3" ], 'ROUTE GET /cook3 sets a cookie with a path';
+
+is-deeply get-psgi-response('GET', '/cook4'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "flavour=chocolate; Path=/test; Domain=example.com"], "cookie test #4" ], 'ROUTE GET /cook4 sets a cookie with a path and domain';
+
+is-deeply get-psgi-response('GET', '/cook5'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "flavour=chocolate; Expires=Wed, 09 Jun 2021 10:18:14 GMT"], "cookie test #5" ], 'ROUTE GET /cook5 sets a cookie with an expiry';
+
+is-deeply get-psgi-response('GET', '/rfc1'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "SID=31d4d96e407aad42"], "rfc" ], 'ROUTE GET /rfc1 sets a cookie like RFC 6265 page 6';
+
+is-deeply get-psgi-response('GET', '/rfc2'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "SID=31d4d96e407aad42; Path=/; Domain=example.com"], "rfc" ], 'ROUTE GET /rfc2 sets a cookie with path and domain like RFC 6265 page 6';
+
+is-deeply get-psgi-response('GET', '/rfc3'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "SID=31d4d96e407aad42; Path=/; Secure; HttpOnly"], "rfc" ], 'ROUTE GET /rfc3 sets a secure httponly cookie with path like RFC 6265 page 6';
+
+is-deeply get-psgi-response('GET', '/rfc4'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "lang=; Expires=Sun, 06 Nov 1994 08:49:37 GMT"], "rfc" ], 'ROUTE GET /rfc4 sets a cookie with with no value like RFC 6265 page 7';
+
+is-deeply get-psgi-response('GET', '/wiki1'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "LSID=DQAAAKEaem_vYg; Path=/accounts; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly"], "wikipedia" ], 'ROUTE GET /wiki1 sets a cookie like an example from the HTTP cookie wikipedia article';
+
+is-deeply get-psgi-response('GET', '/wiki2'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "SSID=Ap4P.GTEq; Path=/; Domain=foo.com; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly"], "wikipedia" ], 'ROUTE GET /wiki2 sets a cookie with all parameters like an example from the HTTP cookie wikipedia article';
+
+is-deeply get-psgi-response('GET', '/multi1'), 
+    [ 200, 
+        [
+            "Content-Type" => "text/html",
+            "Set-Cookie" => "enwikiUserID=127001; Path=/; Expires=Thu, 15 Oct 2015 15:12:40 GMT; Secure; HttpOnly",
+            "Set-Cookie" => "enwikiUserName=localhost; Path=/; Expires=Thu, 15 Oct 2015 15:12:40 GMT; Secure; HttpOnly",
+            "Set-Cookie" => "forceHTTPS=true; Path=/; Expires=Thu, 15 Oct 2015 15:12:40 GMT; HttpOnly"
+        ], "multiple" 
+    ], 'ROUTE GET /multi1 sets multiple cookies';

--- a/t/06-cookies.t
+++ b/t/06-cookies.t
@@ -3,7 +3,7 @@ use Test;
 use Bailador;
 use Bailador::Test;
 
-plan 12;
+plan 14;
 
 get '/cook1' => sub {
     cookie("flavour", "chocolate");
@@ -66,6 +66,16 @@ get '/multi1' => sub {
     "multiple";
 }
 
+get '/escape1' => sub {
+    cookie("key", "value;", :secure);
+    "escape";
+}
+
+get '/escape2' => sub {
+    cookie("the=key", "value", path => "/");
+    "escape";
+}
+
 is-deeply get-psgi-response('GET', '/cook1'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "flavour=chocolate"], "cookie test #1" ], 'ROUTE GET /cook1 sets a cookie';
 
 is-deeply get-psgi-response('GET', '/cook2'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => "flavour=chocolate; Domain=example.com"], "cookie test #2" ], 'ROUTE GET /cook2 sets a cookie with a domain';
@@ -97,3 +107,7 @@ is-deeply get-psgi-response('GET', '/multi1'),
             "Set-Cookie" => "forceHTTPS=true; Path=/; Expires=Thu, 15 Oct 2015 15:12:40 GMT; HttpOnly"
         ], "multiple" 
     ], 'ROUTE GET /multi1 sets multiple cookies';
+
+is-deeply get-psgi-response('GET', '/escape1'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => 'key=value%3B; Secure'], "escape" ], 'ROUTE GET /escape1 sends a cookie with a URI encoded value';
+
+is-deeply get-psgi-response('GET', '/escape2'), [ 200, ["Content-Type" => "text/html", "Set-Cookie" => 'the%3Dkey=value; Path=/'], "escape" ], 'ROUTE GET /escape2 sends a cookie with a URI encoded key';


### PR DESCRIPTION
This alleviates the need for manually creating the cookie string
and adding it as a header. Also makes it possible to send multiple
cookies in one response (previously any additional cookies would
overwrite the previous cookie when setting the Set-Cookie header).