### PR TITLE
small fix in pastebin.pl

### DIFF
--- a/examples/pastebin.pl
+++ b/examples/pastebin.pl
@@ -20,7 +20,7 @@ post '/new_paste' => sub {
     my $fh = open "data/$t", :w;
     $fh.print: $c;
     $fh.close;
-    return qq{New paste available at <a href="/paste/$t">paste/$t\</a>};
+    return qq{New paste available at <a href="paste/$t">paste/$t\</a>};
 }
 
 get /paste\/(\d+)$/ => sub ($tag) {


### PR DESCRIPTION
In case pastebin.pl is not at the root of the website, the link generated by the a anchors would be wrong.