### PR TITLE
Catch errors from the application

### DIFF
--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -131,11 +131,21 @@ sub dispatch($env) {
     my ($r, $match) = $app.find_route($env);
 
     if $r {
-        status 200;
-        if $match {
-            $app.response.content = $r.value.(|$match.list);
-        } else {
-            $app.response.content = $r.value.();
+        try {
+            status 200;
+            if $match {
+                $app.response.content = $r.value.(|$match.list);
+            } else {
+                $app.response.content = $r.value.();
+            }
+            CATCH {
+                default {
+                    $app.request.env<p6sgi.errors>.say(.gist);
+                    status 500;
+                    content_type 'text/plain';
+                    $app.response.content = 'Internal Server Error';
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Prevent Bailador from dieing if the application dies, and convert these
responses to an Internal Server Error response, while printing the
backtrace to the P6SGI error handle (normally `$*ERR`).

After committing this, it occurred to me that this might make more sense in HTTP::Easy::PSGI. If you think that makes more sense, please let me know and I'll port this over.

What would make sense for Bailador, in my opinion, is to have a nice debug mode where we get the backtrace to the screen, similar to things like Django.