### PR TITLE
Test error handling, fix errors in psgi-classic

### DIFF
--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -140,7 +140,9 @@ sub dispatch($env) {
             }
             CATCH {
                 default {
-                    $app.request.env<p6sgi.errors>.say(.gist);
+                    my $env = $app.request.env;
+                    my $err = $env<p6sgi.version>:exists ?? $env<p6sgi.errors> !! $env<psgi.errors>;
+                    $err.say(.gist);
                     status 500;
                     content_type 'text/plain';
                     $app.response.content = 'Internal Server Error';

--- a/lib/Bailador/Test.pm
+++ b/lib/Bailador/Test.pm
@@ -5,16 +5,27 @@ use URI;
 
 unit module Bailador::Test;
 
+# It would be nice to have IO::String here instead
+my class IO::Null is IO::Handle {
+    method print(*@what) {
+        # noop
+    }
+
+    method print-nl(*@what) {
+        # noop
+    }
+}
+
 # preparing a environment variale for PSGI
 sub get-psgi-response($meth, $url, $data = '') is export {
     die "Invalid method '$meth'" if $meth ne 'GET' and $meth ne 'POST';
-	# prefix with http://127.0.0.1:1234 because the URI module cannot handle URI that looks like /foo
+    # prefix with http://127.0.0.1:1234 because the URI module cannot handle URI that looks like /foo
     my $uri = URI.new(($url.substr(0, 1) eq '/' ?? 'http://127.0.0.1:1234' !! '') ~ $url);
 
     my $env = {
         "psgi.multiprocess"    => Bool::False,
         "psgi.multithread"     => Bool::False,
-        "psgi.errors"          => IO::Handle.new(path => IO::Special.new(what => "<STDERR>"), ins => 0, chomp => Bool::True),
+        "psgi.errors"          => IO::Null.new,
         "psgi.streaming"       => Bool::False,
         "psgi.nonblocking"     => Bool::False,
         "psgi.version"         => [1, 0],

--- a/t/07-errors.t
+++ b/t/07-errors.t
@@ -1,0 +1,13 @@
+use Test;
+use Bailador;
+use Bailador::Test;
+
+plan 3;
+
+get '/die' => sub { die "oh no!" }
+get '/fail' => sub { fail "oh no!" }
+get '/exception' => sub { X::NYI.new("NYI").throw }
+
+is-deeply get-psgi-response('GET', '/die'),        [500, ["Content-Type" => "text/plain"], 'Internal Server Error'], 'route GET handles die';
+is-deeply get-psgi-response('GET', '/fail'),       [500, ["Content-Type" => "text/plain"], 'Internal Server Error'], 'route GET handles fail';
+is-deeply get-psgi-response('GET', '/exception'),  [500, ["Content-Type" => "text/plain"], 'Internal Server Error'], 'route GET handles thrown exception';


### PR DESCRIPTION
Add a test for handling errors in applications. Tests use the
psgi-classic mode, so the handle is different for errors. Now we detect
which one to use. This also adds a small IO::Handle subclass to prevent
the errors from the test from cluttering up STDERR.