### PR TITLE
travis: testing only on stable and latest perl 6 releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ language: perl6
 sudo: false
 perl6:
   - latest
-  - 2015.09
-# https://github.com/travis-ci/travis-ci/issues/4910
+  - v6.c
 install:
   - rakudobrew build-panda
   - panda install URI Template::Mojo HTTP::Easy Template::Mustache


### PR DESCRIPTION
Hi!

This PR simply switches the testing bed from `2015.09` to `v6.c`, which makes sense to me since we probably want to check against stable and latest versions only. As a result, the [Travis-CI output](https://travis-ci.org/garu/Bailador/builds/114941493) (and its badge) should be green again :wink: 

Hope it helps! Thanks for this very nice dist!