### PR TITLE
500.html file for Error 500

### DIFF
--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -144,8 +144,12 @@ sub dispatch($env) {
                     my $err = $env<p6sgi.version>:exists ?? $env<p6sgi.errors> !! $env<p6sgi.errors>;
                     $err.say(.gist);
                     status 500;
-                    content_type 'text/plain';
-                    $app.response.content = 'Internal Server Error';
+                    if 'views/500.html'.IO ~~ :e {
+                      $app.response.content = slurp('views/500.html');
+                    } else {
+                      content_type 'text/plain';
+                      $app.response.content = 'Internal Server Error';
+                    }
                 }
             }
         }


### PR DESCRIPTION
When an error 500 is rendered, it will first looks in the `views` directory for an HTML file matching the error code.

If such a file exists, it's used to render the error, otherwise, the default error page will be rendered.