### PR TITLE
incrementing Bailador::Request

### DIFF
--- a/lib/Bailador/Request.pm
+++ b/lib/Bailador/Request.pm
@@ -1,6 +1,8 @@
 class Bailador::Request {
 
     has $.env is rw;
+    has %!cookies;
+    has %!headers;
 
     sub uri_unescape ($uri) {
         use URI::Escape;
@@ -25,40 +27,61 @@ class Bailador::Request {
     }
     multi method params ($source) {
         my %ret;
+        my $source_data = '';
         given $source {
             when 'query' {
-                if $!env<QUERY_STRING> {
-                    for $.env<QUERY_STRING>.split('&') -> $p {
-                        my $pair = $p.split('=', 2);
-                        %ret{$pair[0]} = uri_unescape $pair[1];
-                    }
-                }
+                $source_data = $.env<QUERY_STRING> if $!env<QUERY_STRING>;
             }
             when 'body' {
-                if $!env<p6sgi.input> {
-                    for $.env<p6sgi.input>.decode.split('&') -> $p {
-                        my $pair = $p.split('=', 2);
-                        %ret{$pair[0]} = uri_unescape $pair[1];
-                    }
-                }
+                $source_data = $.env<p6sgi.input>.decode if $!env<p6sgi.input>;
             }
             default {
                 die "unknown source '$source'";
+            }
+        }
+        return %ret unless $source_data.chars;
+
+        for $source_data.split('&') -> $p {
+            my @pair = $p.split('=', 2);
+            if (%ret{@pair[0]}:exists) {
+                %ret.push((@pair[0] => |uri_unescape(@pair[1])));
+            }
+            else {
+                %ret{@pair[0]} = uri_unescape @pair[1];
             }
         }
 
         return %ret;
     }
 
-    method cookies () {
-        my %ret;
-        if $.env<HTTP_COOKIE> {
-            for $.env<HTTP_COOKIE>.split('; ') {
-                my ($name, $value) = $_.split('=', 2);
-                %ret{uri_unescape($name)} = uri_unescape($value);
-            }
+    method headers () {
+        return %!headers if %!headers;
+        for $.env.keys.grep(rx:i/^[HTTP||CONTENT]/) -> $key {
+            my $field = $key;
+            $field ~~ s:i/^HTTPS?_//;
+            %!headers{$field} = $.env{$key};
         }
-        return %ret;
+        return %!headers;
+    }
+
+    method cookies () {
+        return %!cookies if %!cookies || !$.env<HTTP_COOKIE>;
+        for $.env<HTTP_COOKIE>.split(/<[;,]>\s/) -> $cookie {
+            my ($name, $value) = $cookie.trim.split(/\s*\=\s*/, 2);
+            my @values;
+            if $value {
+                @values = $value.split(/<[&;]>/).map: { uri_unescape($_) };
+            }
+            # TODO: build Bailador::Cookie object :)
+            %!cookies{uri_unescape($name)} = @values;
+        }
+        return %!cookies;
+    }
+
+    method is_ajax returns Bool {
+        return True if $.header<X-Requested-With>:exists
+                    && $.header<X-Requested-With> eq 'XMLHttpRequest';
+        return False;
     }
 
     method new_for_request($meth, $path) {
@@ -77,11 +100,20 @@ class Bailador::Request {
     method is_put      { self.method eq 'PUT'    }
     method is_delete   { self.method eq 'DELETE' }
     method is_head     { self.method eq 'HEAD'   }
-    method is_patch    { self.method eq 'PATCH' }
+    method is_patch    { self.method eq 'PATCH'  }
 
     method content_type   { $.env<CONTENT_TYPE>   }
     method content_length { $.env<CONTENT_LENGTH> }
 
     # TODO Shouldn't ignore Content-Type
     method body           { $.env<p6sgi.input>.decode }
+
+    # in Dancer2, these are inherited from Plack::Request
+    method user_agent  { $.headers<USER_AGENT>    }
+    method referer     { $.headers<REFERER>       }
+    method address     { $.env<REMOTE_ADDR>      }
+    method remote_host { $.env<REMOTE_HOST>      }
+    method protocol    { $.env<SERVER_PROTOCOL>  }
+    method user        { $.env<REMOTE_USER>      }
+    method script_name { $.env<SCRIPT_NAME>      }
 }

--- a/lib/Bailador/Request.pm
+++ b/lib/Bailador/Request.pm
@@ -59,7 +59,7 @@ class Bailador::Request {
         for $.env.keys.grep(rx:i/^[HTTP||CONTENT]/) -> $key {
             my $field = $key;
             $field ~~ s:i/^HTTPS?_//;
-            %!headers{$field} = $.env{$key};
+            %!headers{$field.uc} = $.env{$key};
         }
         return %!headers;
     }
@@ -79,8 +79,8 @@ class Bailador::Request {
     }
 
     method is_ajax returns Bool {
-        return True if $.header<X-Requested-With>:exists
-                    && $.header<X-Requested-With> eq 'XMLHttpRequest';
+        return True if $.header<X-REQUESTED-WITH>:exists
+                    && $.header<X-REQUESTED-WITH> eq 'XMLHttpRequest';
         return False;
     }
 

--- a/lib/Bailador/Request.pm
+++ b/lib/Bailador/Request.pm
@@ -27,7 +27,7 @@ class Bailador::Request {
     }
     multi method params ($source) {
         my %ret;
-        my $source_data = '';
+        my Str $source_data;
         given $source {
             when 'query' {
                 $source_data = $.env<QUERY_STRING> if $!env<QUERY_STRING>;
@@ -39,7 +39,7 @@ class Bailador::Request {
                 die "unknown source '$source'";
             }
         }
-        return %ret unless $source_data.chars;
+        return %ret unless $source_data.defined;
 
         for $source_data.split('&') -> $p {
             my @pair = $p.split('=', 2);

--- a/lib/Bailador/Request.pm
+++ b/lib/Bailador/Request.pm
@@ -57,8 +57,7 @@ class Bailador::Request {
     method headers () {
         return %!headers if %!headers;
         for $.env.keys.grep(rx:i/^[HTTP||CONTENT]/) -> $key {
-            my $field = $key;
-            $field ~~ s:i/^HTTPS?_//;
+            my $field = S:i/HTTPS?_// given $key;
             %!headers{$field.uc} = $.env{$key};
         }
         return %!headers;

--- a/t/02-request.t
+++ b/t/02-request.t
@@ -1,0 +1,64 @@
+use Test;
+use Bailador;
+use Bailador::Test;
+
+plan 27;
+
+my %env = (
+        'psgi.url_scheme'    => 'http',
+        REQUEST_METHOD       => 'GET',
+        SCRIPT_NAME          => '/foo',
+        PATH_INFO            => '/bar/baz',
+        REQUEST_URI          => '/foo/bar/baz',
+        QUERY_STRING         => 'foo=42&bar=12&bar=13&bar=14',
+        SERVER_NAME          => 'localhost',
+        SERVER_PORT          => 5000,
+        SERVER_PROTOCOL      => 'HTTP/1.1',
+        REMOTE_ADDR          => '127.0.0.1',
+        HTTP_X_FORWARDED_FOR      => '127.0.0.2',
+        HTTP_X_FORWARDED_HOST     => 'secure.frontend',
+        HTTP_X_FORWARDED_PROTOCOL => 'https',
+        REMOTE_HOST          => 'localhost',
+        HTTP_USER_AGENT      => 'Mozilla',
+        REMOTE_USER          => 'sukria',
+        HTTP_COOKIE          => 'cookie.a=foo=bar; cookie.b=1234abcd; no.value.cookie',
+);
+
+ok my $req = Bailador::Request.new(env => %env), 'request object created';
+isa-ok $req, Bailador::Request;
+
+# testing accessors';
+is $req.user_agent,            'Mozilla';
+is $req.address,               '127.0.0.1';
+is $req.remote_host,           'localhost';
+is $req.protocol,              'HTTP/1.1';
+is $req.port,                  5000;
+is $req.request_uri,           '/foo/bar/baz';
+is $req.uri,                   '/foo/bar/baz';
+is $req.user,                  'sukria';
+is $req.script_name,           '/foo';
+skip '$req.scheme not implemented yet', 1;
+# is $req.scheme,                'http';
+skip '$req.secure not implemented yet', 1;
+#ok( !$req.secure );
+is $req.referer,     Any, 'referer is not defined';
+is $req.method,     'GET', 'got the right method';
+ok $req.is_get,     'is_get() is true for GET request';
+ok !$req.is_post,   'is_post() is false for GET request';
+ok !$req.is_put,    'is_put() is false for GET request';
+ok !$req.is_delete, 'is_delete() is false for GET request';
+ok !$req.is_patch,  'is_patch() is false for GET request';
+ok !$req.is_head,   'is_head() is false for GET request';
+
+# testing request parameters
+#FIXME: is-deeply $req.params, (foo => '42', bar => ['12', '13', '14']), 'request parameters match';
+my %params = $req.params;
+is %params{'foo'}, 42, 'Str param properly received';
+my $bar = %params{'bar'};
+is $bar.elems, 3, '3 elements in "bar"';
+is $bar[0], '12', 'first element looks right';
+is $bar[1], '13', 'second element looks right';
+is $bar[2], '14', 'third element looks right';
+
+# testing cookies on the request
+is $req.cookies.elems, 3, "multiple cookies extracted";


### PR DESCRIPTION
Hi! Thanks for porting Dancer2 to Perl 6 :)

I am trying to use Bailador in a project and realized there are still a lot of things missing. This PR implements some methods that are missing from Dancer2::Request, namely:

* headers
* user_agent
* referer
* address
* remote_host
* protocol
* user
* script_name
* is_ajax

It also implements the following changes in the `cookies()` method:

* cache results
* considers ',' as a separator as well, as per RFC and other implementations
* puts cookie values in array, like Dancer2::Request does
* trims the data

Finally, I also refactored `params()` and allowed it to receive more than one argument (e.g.: /url&foo=42&foo=bar).

All changes and new features have tests included in the commit.

Hope this helps. Thanks again for creating Bailador :)

Cheers!